### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,7 +8,7 @@ jobs:
     - name: Publish to Registry
       env:
         CFNDSL_VERSION: 1.4.0
-      uses: elgohr/Publish-Docker-Github-Action@8e555d3d730d42d274a0435e12f3ef9971ea07c9
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: pkumaschow/cfndsl
         username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore